### PR TITLE
Add configuration to report nightly build failures to Slack

### DIFF
--- a/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/config.yml
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/config.yml
@@ -61,6 +61,10 @@ jobs:
 
       - run: python testmanage.py test
 
+      - run:
+          when: on_fail
+          command: python ./.circleci/report_nightly_build_failure.py
+
 workflows:
     version: 2
     test:

--- a/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/report_nightly_build_failure.py
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/report_nightly_build_failure.py
@@ -1,0 +1,18 @@
+"""
+Called by CircleCI when the nightly build fails.
+
+This reports an error to the #nightly-build-failures Slack channel.
+"""
+import os
+import requests
+
+if 'SLACK_WEBHOOK_URL' in os.environ:
+    print("Reporting to #nightly-build-failures slack channel")
+    response = requests.post(os.environ['SLACK_WEBHOOK_URL'], json={
+        "text": "A Nightly build failed. See " + os.environ['CIRCLE_BUILD_URL'],
+    })
+
+    print("Slack responded with:", response)
+
+else:
+    print("Unable to report to #nightly-build-failures slack channel because SLACK_WEBHOOK_URL is not set")


### PR DESCRIPTION
As per: https://github.com/wagtail/wagtail/wiki/Nightly-testing-of-official-plugins